### PR TITLE
ci: migrate labeler config to v5 format and add MIT LICENSE

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,19 +1,20 @@
 # Ajout automatique des labels selon les fichiers modifiés
 dependencies:
-  - package.json
+  - changed-files:
+      - any-glob-to-any-file: ['package.json', 'package-lock.json']
 
 documentation:
-  - README.md
-  - CHANGELOG.md
-  - ./*.md
+  - changed-files:
+      - any-glob-to-any-file: ['README.md', 'CHANGELOG.md', '*.md']
 
 workflows:
-  - .github/workflows/*
+  - changed-files:
+      - any-glob-to-any-file: '.github/workflows/*'
 
 core:
-  - src/**/*
-  - rollup.config.js
-  - tsconfig.json
+  - changed-files:
+      - any-glob-to-any-file: ['src/**/*', 'rollup.config.js', 'tsconfig.json']
 
 hacs:
-  - hacs.json
+  - changed-files:
+      - any-glob-to-any-file: 'hacs.json'

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Domodom30
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Fixes the 'label' workflow failing on all PRs (labeler v5+ requires the changed-files/any-glob-to-any-file format) and the HACS 'no license' validation error by adding a LICENSE file matching package.json.