### PR TITLE
Deleting (and editing) a mealplan entry fails: expected str at 'mealplan_id'

### DIFF
--- a/src/utils/mealie-api.ts
+++ b/src/utils/mealie-api.ts
@@ -156,12 +156,12 @@ export function addToMealplan(hass: HomeAssistant, options: MealplanEntryOptions
 
 export function updateMealplanEntry(hass: HomeAssistant, options: MealplanEntryOptions & { mealplanId: number }): Promise<void> {
   return withMealieError('error.error_updating_mealplan', () =>
-    callMealieService(hass, 'update_mealplan', { mealplan_id: options.mealplanId, ...buildMealplanPayload(options) }, options.configEntryId)
+    callMealieService(hass, 'update_mealplan', { mealplan_id: String(options.mealplanId), ...buildMealplanPayload(options) }, options.configEntryId)
   );
 }
 
 export function deleteMealplanEntry(hass: HomeAssistant, mealplanId: number, configEntryId?: string): Promise<void> {
-  return withMealieError('error.error_deleting_mealplan', () => callMealieService(hass, 'delete_mealplan', { mealplan_id: mealplanId }, configEntryId));
+  return withMealieError('error.error_deleting_mealplan', () => callMealieService(hass, 'delete_mealplan', { mealplan_id: String(mealplanId) }, configEntryId));
 }
 
 export function setRandomMealplan(hass: HomeAssistant, options: { configEntryId?: string; date: string; entryType: EntryType }): Promise<void> {


### PR DESCRIPTION
## Problem

Deleting or editing a mealplan entry from the mealplan card fails. The card shows "Error deleting meal", and Home Assistant rejects the action with:

```
expected str at 'mealplan_id'
```

## Cause

Home Assistant's built-in Mealie integration only accepts `mealplan_id` as a string for `delete_mealplan` and `update_mealplan`:

```python
vol.Required(ATTR_MEALPLAN_ID): str
```

This check does not convert numbers. The card passes `mealplan_id` straight from `get_mealplan`, where it is an integer, so the call is rejected before it reaches Mealie.

## Reproduction

In **Developer Tools → Actions**:

```yaml
action: mealie.delete_mealplan
data:
  config_entry_id: YOUR_ENTRY_ID
  mealplan_id: 123    # fails: expected str at 'mealplan_id'
```

With `mealplan_id: "123"` (quoted), the entry is deleted.

## Fix

Convert the ID with `String()` in `src/utils/mealie-api.ts` before calling `delete_mealplan` and `update_mealplan`.

`dist/mealie-card.js` is not rebuilt in this PR.

## Environment

- mealie-card v3.0.6
- Home Assistant 2026.9.1
